### PR TITLE
Fix browser compatibility by adding browser-safe entry point

### DIFF
--- a/mod.browser.ts
+++ b/mod.browser.ts
@@ -1,0 +1,3 @@
+export * from './src/capability/index.js'
+export * from './src/paymailClient/index.js'
+export * from './src/errors/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/paymail",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/paymail",
-      "version": "2.2.5",
+      "version": "2.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/sdk": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/mod.d.ts",
+      "browser": "./dist/esm/mod.browser.js",
       "import": "./dist/esm/mod.js",
       "require": "./dist/cjs/mod.js"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/paymail",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "BSV Paymail library",
   "publishConfig": {
     "access": "public"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
-  "files": ["mod.ts"],
+  "files": ["mod.ts", "mod.browser.ts"],
   "include": ["src"],
   "exclude": ["dist", "*/**/__tests"]
 }


### PR DESCRIPTION
Adds mod.browser.ts that excludes the Express-based paymailRouter,
which depends on node:http and cannot run in browser environments.
Updates package.json exports with a browser condition to point to this
module, and updates tsconfig.base.json to compile it.

Fixes #36 (Cannot read properties of undefined in web browser)

https://claude.ai/code/session_01DzpMMMKx3whiEdzNTYHY83